### PR TITLE
Missing semi-colon on CREATE INDEX statements

### DIFF
--- a/reorder.py
+++ b/reorder.py
@@ -304,7 +304,7 @@ SELECT
       n.nspname AS schema_name
     , c.relname AS table_name
     , i.relname AS index_name
-    , pg_get_indexdef(i.oid) AS index_def
+    , pg_get_indexdef(i.oid) || ';' AS index_def
 FROM
     pg_catalog.pg_index x
 JOIN pg_catalog.pg_class c


### PR DESCRIPTION
Semi-colon isn't present on CREATE INDEX statements.  This PR adds them.  This is needed such that a generated SQL file can be executed in migrations.